### PR TITLE
EM-134: Fixes to metaFields and reset

### DIFF
--- a/AdaEmbedFramework.xcodeproj/xcuserdata/nicholashaley.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AdaEmbedFramework.xcodeproj/xcuserdata/nicholashaley.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>AdaEmbedFramework.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>4</integer>
+			<integer>0</integer>
 		</dict>
 		<key>EmbedFramework.xcscheme_^#shared#^_</key>
 		<dict>
@@ -17,7 +17,7 @@
 		<key>ExampleApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>5</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -20,7 +20,7 @@ public class AdaWebHost: NSObject {
     
     /// Metafields can be passed in during init; use `setMetaFields()`
     /// to send values in at runtime
-    private var metafields: [String: String]?
+    private var metafields: [String: String] = [:]
     
     public var openWebLinksInSafari = false
     public var appScheme = ""
@@ -52,7 +52,7 @@ public class AdaWebHost: NSObject {
     /// If commands are sent prior to `embedReady`, store until it can be cleared out
     private var pendingCommands = [String]()
     
-    public init(handle: String, cluster: String = "", language: String = "", styles: String = "", greeting: String = "", metafields: [String: String]? = [:], openWebLinksInSafari: Bool = false, appScheme: String = "") {
+    public init(handle: String, cluster: String = "", language: String = "", styles: String = "", greeting: String = "", metafields: [String: String] = [:], openWebLinksInSafari: Bool = false, appScheme: String = "") {
         self.handle = handle
         self.cluster = cluster
         self.language = language
@@ -243,14 +243,12 @@ extension AdaWebHost {
                 "cluster": self.cluster,
                 "language": self.language,
                 "styles": self.styles,
-                "greeting": self.greeting
+                "greeting": self.greeting,
+                "metaFields": self.metafields
                 ] as [String : Any]
             let serializedData = try JSONSerialization.data(withJSONObject: dictionaryData, options: [])
             let encodedData = serializedData.base64EncodedString()
             evalJS("initializeEmbed('\(encodedData)');")
-            if let metafields = self.metafields {
-                setMetaFields(metafields)
-            }
         } catch (let error) {
             print("Serialization error: \(error.localizedDescription)")
             return

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -115,7 +115,7 @@ public class AdaWebHost: NSObject {
     }
     
     /// Re-initialize chat and optionally reset history, language, meta data, etc
-    public func reset(language: String? = nil, greeting: String? = nil, metaFields: [String: Any]? = nil, resetChatHistory: Bool? = nil) {
+    public func reset(language: String? = nil, greeting: String? = nil, metaFields: [String: Any]? = nil, resetChatHistory: Bool? = true) {
         
         let data: [String: Any?] = [
             "language": language,


### PR DESCRIPTION
This PR addresses two bugs:

- Meta variables were not working in greeting messages. This is because the SDK was using `setMetaFields` to set initial values. This causes a known race condition.
- The reset method was not clearing chat history by default