### PR TITLE
Update auth callback naming

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.2.1"
+  spec.version      = "1.3.0"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -25,7 +25,7 @@ public class AdaWebHost: NSObject {
     public var openWebLinksInSafari = false
     public var appScheme = ""
     
-    public var zdChatterAuthCallback: ((((_ token: String) -> Void)) -> Void)?
+    public var zdChatterAuthCallback: (((@escaping (_ token: String) -> Void)) -> Void)?
     
     /// Here's where we do our business
     private var webView: WKWebView?
@@ -63,7 +63,7 @@ public class AdaWebHost: NSObject {
         metafields: [String: String] = [:],
         openWebLinksInSafari: Bool = false,
         appScheme: String = "",
-        zdChatterAuthCallback: ((((_ token: String) -> Void)) -> Void)? = nil
+        zdChatterAuthCallback: (((@escaping (_ token: String) -> Void)) -> Void)? = nil
     ) {
         self.handle = handle
         self.cluster = cluster
@@ -249,7 +249,7 @@ extension AdaWebHost: WKScriptMessageHandler {
             self.webHostLoaded = true
         } else if let zdChatterAuthCallback = self.zdChatterAuthCallback, messageBodyString == "getToken" {
             zdChatterAuthCallback() { token in
-                evalJS("window.zdTokenCallback(\"\(token)\");")
+                self.evalJS("window.zdTokenCallback(\"\(token)\");")
             }
         }
     }

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -249,7 +249,7 @@ extension AdaWebHost: WKScriptMessageHandler {
             self.webHostLoaded = true
         } else if let zdChatterAuthCallback = self.zdChatterAuthCallback, messageBodyString == "getToken" {
             zdChatterAuthCallback() { token in
-                evalJS("window.authTokenCallback(\"\(token)\");")
+                evalJS("window.zdTokenCallback(\"\(token)\");")
             }
         }
     }
@@ -271,8 +271,8 @@ extension AdaWebHost {
                         greeting: "\(self.greeting)",
                         metaFields: \(json),
                         parentElement: "parent-element",
-                        authCallback: function(callback) {
-                            window.authTokenCallback = callback;
+                        zdChatterAuthCallback: function(callback) {
+                            window.zdTokenCallback = callback;
                             window.webkit.messageHandlers.embedReady.postMessage("getToken");
                         }
                     });

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -11,7 +11,9 @@ import AdaEmbedFramework
 
 class ViewController: UIViewController {
     
-    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp")
+    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", zdChatterAuthCallback: { callback in
+        callback("JWT TOKEN")
+    })
     
     @IBOutlet var firstNameField: UITextField!
     @IBOutlet var lastNameField: UITextField!

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -11,9 +11,7 @@ import AdaEmbedFramework
 
 class ViewController: UIViewController {
     
-    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", zdChatterAuthCallback: { callback in
-        callback("JWT TOKEN")
-    })
+    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp")
     
     @IBOutlet var firstNameField: UITextField!
     @IBOutlet var lastNameField: UITextField!


### PR DESCRIPTION
### Description
- Naming improvements
- Add escaping to callback function definition so that the `callback` may be called after the JWT HTTP call has returned (eg. this allows it to work asynchronously).
- Bump Cocoapod version

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.