### PR TITLE
CXP-187: Deprecate mobile-sdk-webview

### DIFF
--- a/AdaEmbedFramework.xcodeproj/project.pbxproj
+++ b/AdaEmbedFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		491F4E5D24A6A32300025FCF /* AdaEmbed.html in Resources */ = {isa = PBXBuildFile; fileRef = 491F4E5C24A6A32300025FCF /* AdaEmbed.html */; };
 		49C73563226F99FE00D22E4B /* AdaEmbedFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49C73559226F99FE00D22E4B /* AdaEmbedFramework.framework */; };
 		49C73568226F99FE00D22E4B /* EmbedFrameworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C73567226F99FE00D22E4B /* EmbedFrameworkTests.swift */; };
 		49C7356A226F99FE00D22E4B /* EmbedFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 49C7355C226F99FE00D22E4B /* EmbedFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -60,6 +61,7 @@
 		26BCD96559D811599DFCFA56 /* Pods-AdaEmbedFramework.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaEmbedFramework.release.xcconfig"; path = "Target Support Files/Pods-AdaEmbedFramework/Pods-AdaEmbedFramework.release.xcconfig"; sourceTree = "<group>"; };
 		319C585ECB42770D19E19753 /* Pods-AdaEmbedFramework-AdaEmbedFrameworkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaEmbedFramework-AdaEmbedFrameworkTests.release.xcconfig"; path = "Target Support Files/Pods-AdaEmbedFramework-AdaEmbedFrameworkTests/Pods-AdaEmbedFramework-AdaEmbedFrameworkTests.release.xcconfig"; sourceTree = "<group>"; };
 		389A38EA3B28D4803B940430 /* Pods-AdaEmbedFramework.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaEmbedFramework.debug.xcconfig"; path = "Target Support Files/Pods-AdaEmbedFramework/Pods-AdaEmbedFramework.debug.xcconfig"; sourceTree = "<group>"; };
+		491F4E5C24A6A32300025FCF /* AdaEmbed.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = AdaEmbed.html; path = ../../../../Desktop/AdaEmbed.html; sourceTree = "<group>"; };
 		49C73559226F99FE00D22E4B /* AdaEmbedFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AdaEmbedFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		49C7355C226F99FE00D22E4B /* EmbedFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmbedFramework.h; sourceTree = "<group>"; };
 		49C7355D226F99FE00D22E4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 		49C7355B226F99FE00D22E4B /* EmbedFramework */ = {
 			isa = PBXGroup;
 			children = (
+				491F4E5C24A6A32300025FCF /* AdaEmbed.html */,
 				49C7355C226F99FE00D22E4B /* EmbedFramework.h */,
 				49C7355D226F99FE00D22E4B /* Info.plist */,
 				93A79797228C871200499BF9 /* AdaWebHost.swift */,
@@ -308,6 +311,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				491F4E5D24A6A32300025FCF /* AdaEmbed.html in Resources */,
 				936ED6B9228F471800796860 /* AdaWebHostViewController.storyboard in Resources */,
 				938BBFD122A93F1B000012A9 /* Assets.xcassets in Resources */,
 			);

--- a/EmbedFramework/AdaEmbed.html
+++ b/EmbedFramework/AdaEmbed.html
@@ -22,10 +22,10 @@
     <script
         async
         id="__ada"
-        src="https://static.ada.support/embed.js"
+        src="https://static.ada.support/embed2.js"
         data-lazy
         onload="onLoadHandler()"
-        ></script>
+    ></script>
     <script>
         function onLoadHandler() {
             // Tell framework Embed is ready
@@ -34,29 +34,6 @@
             } catch(err) {
                 console.error("Can not reach native code");
             }
-        }
-    
-        function initializeEmbed(data) {
-            const decodedData = window.atob(data)
-            const parsedData = JSON.parse(decodedData)
-            const { handle, cluster, language, styles, greeting, metaFields } = parsedData;
-            
-            adaEmbed.start({
-                           handle,
-                           parentElement: "parent-element",
-                           cluster,
-                           language,
-                           styles,
-                           greeting,
-                           metaFields
-                           });
-        }
-    
-        function setMetaFields(data) {
-            const decodedData = window.atob(data)
-            const parsedData = JSON.parse(decodedData)
-            
-            adaEmbed.setMetaFields(parsedData);
         }
     </script>
 </html>


### PR DESCRIPTION
This PR is intended to deprecate the mobile-sdk-webview with a local HTML file. This will help to simplify architecture, make code changes to the HTML file easier, and increase loading speed of the Chat window.

Everything seems to be working fine except for persistence. When closing the app and re-opening, chatter persistence is never maintained.

This seems to be an issue relating to setting localStorage in the Webview with a local file. I've tried this SO suggestion, but so far no luck. Not sure if this is possible.

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.