### PR TITLE
CXP-390: Fixes issue with non-HTTP(S) URL Schemes

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.3.0"
+  spec.version      = "1.3.1"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"

--- a/AdaEmbedFramework.xcodeproj/xcshareddata/xcschemes/ExampleApp.xcscheme
+++ b/AdaEmbedFramework.xcodeproj/xcshareddata/xcschemes/ExampleApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1170"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "93A79780228C86D600499BF9"
+               BuildableName = "ExampleApp.app"
+               BlueprintName = "ExampleApp"
+               ReferencedContainer = "container:AdaEmbedFramework.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93A79780228C86D600499BF9"
+            BuildableName = "ExampleApp.app"
+            BlueprintName = "ExampleApp"
+            ReferencedContainer = "container:AdaEmbedFramework.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93A79780228C86D600499BF9"
+            BuildableName = "ExampleApp.app"
+            BlueprintName = "ExampleApp"
+            ReferencedContainer = "container:AdaEmbedFramework.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AdaEmbedFramework.xcodeproj/xcuserdata/nicholashaley.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/AdaEmbedFramework.xcodeproj/xcuserdata/nicholashaley.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Bucket
+   uuid = "8757098A-6324-49EA-84E3-E05BCF8AE3F0"
    type = "1"
    version = "2.0">
 </Bucket>

--- a/AdaEmbedFramework.xcodeproj/xcuserdata/nicholashaley.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AdaEmbedFramework.xcodeproj/xcuserdata/nicholashaley.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>AdaEmbedFramework.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>EmbedFramework.xcscheme_^#shared#^_</key>
 		<dict>
@@ -17,7 +17,15 @@
 		<key>ExampleApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>93A79780228C86D600499BF9</key>
+		<dict>
+			<key>primary</key>
+			<true/>
 		</dict>
 	</dict>
 </dict>

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -212,10 +212,14 @@ extension AdaWebHost {
 
 extension AdaWebHost: WKNavigationDelegate, WKUIDelegate {
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Swift.Void) {
+        let httpSchemes = ["http", "https"]
+        
         if navigationAction.navigationType == WKNavigationType.linkActivated {
             if let url = navigationAction.request.url {
-                // Handle a universal link from the chat
-                if url.scheme == self.appScheme {
+                let urlScheme = url.scheme
+                // Handle opening universal links within the host App
+                // This requires the appScheme argument to work
+                if urlScheme == self.appScheme {
                     guard let presentingVC = findViewController(from: webView) else { return }
                     presentingVC.dismiss(animated: true) {
                         let shared = UIApplication.shared
@@ -224,16 +228,15 @@ extension AdaWebHost: WKNavigationDelegate, WKUIDelegate {
                         }
                     }
                 // Handle opening links in Safari, if set
-                } else if self.openWebLinksInSafari {
+                } else if self.openWebLinksInSafari == false && httpSchemes.contains(urlScheme ?? "") {
+                    let sfVC = SFSafariViewController(url: url)
+                    guard let presentingVC = findViewController(from: webView) else { return }
+                    presentingVC.present(sfVC, animated: true, completion: nil)
+                } else {
                     let shared = UIApplication.shared
                     if shared.canOpenURL(url) {
                         shared.open(url, options: [:], completionHandler: nil)
                     }
-                // Handle opening links in a local web view
-                } else {
-                    let sfVC = SFSafariViewController(url: url)
-                    guard let presentingVC = findViewController(from: webView) else { return }
-                    presentingVC.present(sfVC, animated: true, completion: nil)
                 }
             }
             decisionHandler(.cancel)

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -227,7 +227,7 @@ extension AdaWebHost: WKNavigationDelegate, WKUIDelegate {
                             shared.open(url, options: [:], completionHandler: nil)
                         }
                     }
-                // Handle opening links in Safari, if set
+                // Only open links in Safari if URL uses HTTP(S) scheme, and the openWebLinksInSafari option is set
                 } else if self.openWebLinksInSafari == false && httpSchemes.contains(urlScheme ?? "") {
                     let sfVC = SFSafariViewController(url: url)
                     guard let presentingVC = findViewController(from: webView) else { return }

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -227,7 +227,7 @@ extension AdaWebHost: WKNavigationDelegate, WKUIDelegate {
                             shared.open(url, options: [:], completionHandler: nil)
                         }
                     }
-                // Only open links in Safari if URL uses HTTP(S) scheme, and the openWebLinksInSafari option is set
+                // Only open links in in-app WebView if URL uses HTTP(S) scheme, and the openWebLinksInSafari option is false
                 } else if self.openWebLinksInSafari == false && httpSchemes.contains(urlScheme ?? "") {
                     let sfVC = SFSafariViewController(url: url)
                     guard let presentingVC = findViewController(from: webView) else { return }


### PR DESCRIPTION
### Description
When using the iOS SDK with the `openWebLinksInSafari` feature turned off (which is also the default), URLs with non-HTTP/HTTPS schemes would cause the app to crash. Such schemes include `tel` and `mailto`.

This PR modifies some of the logic to allow for `tel` and `mailto` to work with or without the `openWebLinksInSafari` option.

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.