### PR TITLE
SUP-123: Calling adaEmbed.setMetafields instead of setMetafields

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.3.1"
+  spec.version      = "1.3.3"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -124,9 +124,9 @@ public class AdaWebHost: NSObject {
     
     /// Push a dictionary of fields to the server
     public func setMetaFields(_ fields: [String: Any]) {
-        let serializedData = try! JSONSerialization.data(withJSONObject: fields, options: [])
-        let encodedData = serializedData.base64EncodedString()
-        let toRun = "setMetaFields('\(encodedData)');"
+        guard let json = try? JSONSerialization.data(withJSONObject: fields, options: []),
+              let jsonString = String(data: json, encoding: .utf8) else { return }
+        let toRun = "adaEmbed.setMetaFields('\(jsonString)');"
         
         self.evalJS(toRun)
     }


### PR DESCRIPTION
### Description
*Changed from calling setMetafields in webview to calling the adaEmbed.setMetaFields. This is because the atob in javascript does not support decoding utf8 from base64 (only supports ASCII)*

---
### Checklist

- [x] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [x] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.