### PR TITLE
SUP-370: Updating cocoapod and fixing bug with quotes around jsonString

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.3.3"
+  spec.version      = "1.3.4"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -126,7 +126,7 @@ public class AdaWebHost: NSObject {
     public func setMetaFields(_ fields: [String: Any]) {
         guard let json = try? JSONSerialization.data(withJSONObject: fields, options: []),
               let jsonString = String(data: json, encoding: .utf8) else { return }
-        let toRun = "adaEmbed.setMetaFields('\(jsonString)');"
+        let toRun = "adaEmbed.setMetaFields(\(jsonString));"
         
         self.evalJS(toRun)
     }


### PR DESCRIPTION
### Description
`jsonString` in setMetaFields had quotes around it thus sending only a string to `adaEmbed.setMetafields`. I've removed the quotes so it sends an object instead. Below you can see that the dashboard is now correctly receiving an object.

![Screen Shot 2021-03-22 at 10 11 42 PM](https://user-images.githubusercontent.com/77396392/112082820-5f79c500-8b5c-11eb-979f-653bc0a8f1ed.png)


---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.