### PR TITLE
SUP-377: Method to remove event listeners to allow WebView to be released from Memory

### DIFF
--- a/AdaEmbedFramework.xcodeproj/project.pbxproj
+++ b/AdaEmbedFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0319A3D9260D29030096ED0A /* AdaScriptMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0319A3D8260D29030096ED0A /* AdaScriptMessageHandler.swift */; };
 		49C73563226F99FE00D22E4B /* AdaEmbedFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49C73559226F99FE00D22E4B /* AdaEmbedFramework.framework */; };
 		49C73568226F99FE00D22E4B /* EmbedFrameworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C73567226F99FE00D22E4B /* EmbedFrameworkTests.swift */; };
 		49C7356A226F99FE00D22E4B /* EmbedFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 49C7355C226F99FE00D22E4B /* EmbedFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -57,6 +58,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0319A3D8260D29030096ED0A /* AdaScriptMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaScriptMessageHandler.swift; sourceTree = "<group>"; };
 		26BCD96559D811599DFCFA56 /* Pods-AdaEmbedFramework.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaEmbedFramework.release.xcconfig"; path = "Target Support Files/Pods-AdaEmbedFramework/Pods-AdaEmbedFramework.release.xcconfig"; sourceTree = "<group>"; };
 		319C585ECB42770D19E19753 /* Pods-AdaEmbedFramework-AdaEmbedFrameworkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaEmbedFramework-AdaEmbedFrameworkTests.release.xcconfig"; path = "Target Support Files/Pods-AdaEmbedFramework-AdaEmbedFrameworkTests/Pods-AdaEmbedFramework-AdaEmbedFrameworkTests.release.xcconfig"; sourceTree = "<group>"; };
 		389A38EA3B28D4803B940430 /* Pods-AdaEmbedFramework.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaEmbedFramework.debug.xcconfig"; path = "Target Support Files/Pods-AdaEmbedFramework/Pods-AdaEmbedFramework.debug.xcconfig"; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				938BBFD222A94100000012A9 /* OfflineViewController.swift */,
 				938BBFD022A93F1B000012A9 /* Assets.xcassets */,
 				938BBFD422A94304000012A9 /* Reachability.swift */,
+				0319A3D8260D29030096ED0A /* AdaScriptMessageHandler.swift */,
 			);
 			path = EmbedFramework;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				938BBFD322A94100000012A9 /* OfflineViewController.swift in Sources */,
+				0319A3D9260D29030096ED0A /* AdaScriptMessageHandler.swift in Sources */,
 				936ED6B7228F438800796860 /* AdaWebHostViewController.swift in Sources */,
 				938BBFD522A94304000012A9 /* Reachability.swift in Sources */,
 				93A79798228C871200499BF9 /* AdaWebHost.swift in Sources */,

--- a/EmbedFramework/AdaScriptMessageHandler.swift
+++ b/EmbedFramework/AdaScriptMessageHandler.swift
@@ -1,0 +1,24 @@
+//
+//  ScriptMessageHandlerWithLeakAvoidance.swift
+//  AdaEmbedFramework
+//
+//  Created by Mike Lazzaro on 2021-03-25.
+//  Copyright © 2021 Ada Support. All rights reserved.
+//
+
+import WebKit
+import Foundation
+
+// This is to allow AdaWebHost to deinit after the events have been removed. Since AdaWebHost contains a strong reference
+// for WKScriptMessageHandler this allows us to set a weak reference to the AdaWebHost class when binding with userContentController
+class AdaScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    weak var delegate : WKScriptMessageHandler?
+    init(delegate:WKScriptMessageHandler) {
+        self.delegate = delegate
+        super.init()
+    }
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            self.delegate?.userContentController(
+                userContentController, didReceive: message)
+    }
+}

--- a/ExampleApp/Main.storyboard
+++ b/ExampleApp/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YZz-zj-PLA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YZz-zj-PLA">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,12 +18,38 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
-                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="srm-oo-wHd"/>
+                        <segue destination="l4a-Pd-zWG" kind="relationship" relationship="rootViewController" id="2p7-c5-BgK"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ozn-FK-ufe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-791" y="138"/>
+            <point key="canvasLocation" x="-1951" y="138"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="CdR-S4-yGr">
+            <objects>
+                <viewController id="l4a-Pd-zWG" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="olz-Bs-1S7">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH0-aa-aj7">
+                                <rect key="frame" x="190" y="433" width="34" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Start"/>
+                                <connections>
+                                    <segue destination="BYZ-38-t0r" kind="show" id="bCm-I1-UMK"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="wSv-Ue-lx2"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="AKM-8s-Mr5"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="JTr-Sx-d5t" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-925" y="138"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
@@ -101,7 +128,7 @@
                                             </textField>
                                         </subviews>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="22T-yn-64K">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="22T-yn-64K">
                                         <rect key="frame" x="0.0" y="150" width="374" height="33"/>
                                         <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
@@ -126,7 +153,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UtT-DW-ACa">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UtT-DW-ACa">
                                 <rect key="frame" x="82" y="438" width="250" height="44"/>
                                 <color key="backgroundColor" red="0.58105844259999995" green="0.12855249639999999" blue="0.57453137639999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -141,7 +168,7 @@
                                     <action selector="openModalSupport:" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="mnV-xB-gNT"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lHt-FX-CIJ">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lHt-FX-CIJ">
                                 <rect key="frame" x="82" y="490" width="250" height="44"/>
                                 <color key="backgroundColor" red="0.58081901069999997" green="0.088427625600000004" blue="0.31863921880000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -156,7 +183,7 @@
                                     <action selector="openNavigationControllerSupport:" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="fws-R3-Vka"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yPq-pX-NTs">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yPq-pX-NTs">
                                 <rect key="frame" x="82" y="542" width="250" height="44"/>
                                 <color key="backgroundColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -171,21 +198,30 @@
                                     <segue destination="r5d-3u-sPX" kind="show" identifier="injectingViewIdentifier" id="ejM-Nj-Phr"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="u7d-xJ-5Ec">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="u7d-xJ-5Ec">
                                 <rect key="frame" x="158" y="674" width="98" height="30"/>
                                 <state key="normal" title="Delete History"/>
                                 <connections>
                                     <action selector="deleteHistory:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mTj-fs-xpq"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5df-SD-wH8">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5df-SD-wH8">
                                 <rect key="frame" x="187.5" y="636" width="39" height="30"/>
                                 <state key="normal" title="Reset"/>
                                 <connections>
                                     <action selector="resetChat:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hxr-p4-oo1"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OoC-wZ-ItO">
+                                <rect key="frame" x="147" y="712" width="120" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Destroy Listeners"/>
+                                <connections>
+                                    <action selector="deleteListeners:" destination="BYZ-38-t0r" eventType="touchUpInside" id="N5C-dr-nZX"/>
+                                </connections>
+                            </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="bEe-yh-TE2" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="0zO-42-DUU"/>
@@ -208,7 +244,6 @@
                             <constraint firstItem="5df-SD-wH8" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="wrW-AO-OMx"/>
                             <constraint firstItem="TnO-pk-bj3" firstAttribute="top" secondItem="QAq-Ol-ajH" secondAttribute="bottom" constant="52" id="yTW-0g-3tv"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="0vo-JG-3j1"/>
                     <connections>
@@ -234,6 +269,7 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Lbn-wG-oG7"/>
                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="ods-VB-DGX" firstAttribute="leading" secondItem="Lbn-wG-oG7" secondAttribute="leading" constant="20" id="B4T-Rp-hqE"/>
@@ -241,8 +277,8 @@
                             <constraint firstItem="Lbn-wG-oG7" firstAttribute="bottom" secondItem="ods-VB-DGX" secondAttribute="bottom" constant="30" id="pMd-38-6WE"/>
                             <constraint firstItem="ods-VB-DGX" firstAttribute="top" secondItem="Lbn-wG-oG7" secondAttribute="top" constant="30" id="rOZ-Rc-RyM"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Lbn-wG-oG7"/>
                     </view>
+                    <navigationItem key="navigationItem" id="ouu-Sf-2Yt"/>
                     <connections>
                         <outlet property="injectingView" destination="ods-VB-DGX" id="olh-DN-wKi"/>
                     </connections>
@@ -252,4 +288,9 @@
             <point key="canvasLocation" x="992.75362318840587" y="137.94642857142856"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -12,6 +12,7 @@ import AdaEmbedFramework
 class ViewController: UIViewController {
     
     lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp")
+        
     
     @IBOutlet var firstNameField: UITextField!
     @IBOutlet var lastNameField: UITextField!
@@ -44,6 +45,10 @@ class ViewController: UIViewController {
     
     @IBAction func deleteHistory(_ sender: UIButton) {
         adaFramework.deleteHistory()
+    }
+    
+    @IBAction func deleteListeners(_ sender: UIButton) {
+        adaFramework.destroyListeners()
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
### Why is this Needed?

- Freshly has found that if they open the WebView over and over it does not destroy the previous instances of the WebView. I am not sure if this was intentional to allow notifications to work across the app so I have added a method instead for now to allow them to destroy the listeners which will allow the `WebView` to clear from memory when it can `deinit`

### Description
- Added `destroyListeners()` method to cleanup any strong references to allow `WebView` to be destroyed if needed (`deinit`)
- Added additional View and Button to trigger this method.

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.