### PR TITLE
SUP-377: Error Callback with Example

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.3.4"
+  spec.version      = "1.3.5"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -31,7 +31,7 @@ public class AdaWebHost: NSObject {
     public var appScheme = ""
     
     
-    public var errorCallback: ((Error) -> Void)? = nil
+    public var WebViewLoadingErrorCallback: ((Error) -> Void)? = nil
     public var zdChatterAuthCallback: (((@escaping (_ token: String) -> Void)) -> Void)?
     public var eventCallbacks: [String: (_ event: [String: Any]) -> Void]?
     
@@ -72,7 +72,7 @@ public class AdaWebHost: NSObject {
         openWebLinksInSafari: Bool = false,
         appScheme: String = "",
         zdChatterAuthCallback: (((@escaping (_ token: String) -> Void)) -> Void)? = nil,
-        errorCallback: ((Error) -> Void)? = nil,
+        WebViewLoadingErrorCallback: ((Error) -> Void)? = nil,
         eventCallbacks: [String: (_ event: [String: Any]) -> Void]? = nil
     ) {
         self.handle = handle
@@ -84,7 +84,7 @@ public class AdaWebHost: NSObject {
         self.openWebLinksInSafari = openWebLinksInSafari
         self.appScheme = appScheme
         self.zdChatterAuthCallback = zdChatterAuthCallback
-        self.errorCallback = errorCallback
+        self.WebViewLoadingErrorCallback = WebViewLoadingErrorCallback
         self.eventCallbacks = eventCallbacks
     
         self.reachability = Reachability()!
@@ -231,7 +231,7 @@ extension AdaWebHost {
                 webView.stopLoading()
                 timerCount = 0.0
                 timer.invalidate()
-                self.errorCallback?(AdaWebHostError.WebViewFailedToLoad)
+                self.WebViewLoadingErrorCallback?(AdaWebHostError.WebViewFailedToLoad)
                 return
             }
             

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -229,6 +229,7 @@ extension AdaWebHost {
             // call error callback and stop trying to load the webview
             if(self.hasError || timerCount >= timeout){
                 webView.stopLoading()
+                timerCount = 0.0
                 timer.invalidate()
                 self.errorCallback?(AdaWebHostError.WebViewFailedToLoad)
                 return
@@ -237,7 +238,7 @@ extension AdaWebHost {
             
             // If we loaded and didn't run over the timer
             // reset count and stop timer
-            timerCount = 0.0;
+            timerCount = 0.0
             timer.invalidate()
         }
 

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -90,6 +90,7 @@ public class AdaWebHost: NSObject {
         self.webViewLoadingErrorCallback = webViewLoadingErrorCallback
         self.eventCallbacks = eventCallbacks
         self.webViewTimeout = webViewTimeout
+        self.hasError = false
     
         self.reachability = Reachability()!
         super.init()
@@ -234,6 +235,7 @@ extension AdaWebHost {
 
 extension AdaWebHost: WKNavigationDelegate, WKUIDelegate {
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            /// Whena  reset method is built - we will need to set this back to false
             self.hasError = true
             self.webViewLoadingErrorCallback?(AdaWebHostError.WebViewFailedToLoad)
     }

--- a/EmbedFramework/AdaWebHostViewController.swift
+++ b/EmbedFramework/AdaWebHostViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 import WebKit
 
 class AdaWebHostViewController: UIViewController {
-    
     static func createWebController(with webView: WKWebView) -> AdaWebHostViewController {
         let bundle = Bundle(for: AdaWebHostViewController.self)
         let storyboard = UIStoryboard(name: "AdaWebHostViewController", bundle: bundle)

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import AdaEmbedFramework
 
 class ViewController: UIViewController {
-    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", WebViewLoadingErrorCallback: LoadingErrorCallback)
+    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", webViewLoadingErrorCallback: LoadingErrorCallback, webViewTimeout: 30.0)
     
     @IBOutlet var firstNameField: UITextField!
     @IBOutlet var lastNameField: UITextField!

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -10,12 +10,20 @@ import UIKit
 import AdaEmbedFramework
 
 class ViewController: UIViewController {
-    
-    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp")
+    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", errorCallback: errorCallback)
     
     @IBOutlet var firstNameField: UITextField!
     @IBOutlet var lastNameField: UITextField!
     @IBOutlet var emailField: UITextField!
+    
+    
+    //Example error callback
+    func errorCallback(error: Error){
+        // Handle any error logic here
+        view.window?.rootViewController?.dismiss(animated: true, completion: nil)
+        navigationController?.popToRootViewController(animated: true);
+        print(error)
+    }
 
     @IBAction func submitForm(_ sender: UIButton) {
         guard

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import AdaEmbedFramework
 
 class ViewController: UIViewController {
-    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", errorCallback: errorCallback)
+    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", WebViewLoadingErrorCallback: LoadingErrorCallback)
     
     @IBOutlet var firstNameField: UITextField!
     @IBOutlet var lastNameField: UITextField!
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
     
     
     //Example error callback
-    func errorCallback(error: Error){
+    func LoadingErrorCallback(error: Error){
         // Handle any error logic here
         view.window?.rootViewController?.dismiss(animated: true, completion: nil)
         navigationController?.popToRootViewController(animated: true);


### PR DESCRIPTION
### Why do we need this change?
Client reported `WebView` would time out on really slow connections and would not provide any error callback to let them know it had failed. They would like to know its failed so they can act on it.

### Description
- Added error callback to example view
- Added timeout handling to `WebView` initialization
- Capturing whether the `WebView` failed to load or timed out and calling error callback if there is one.

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.