### PR TITLE
Fix retain cycles

### DIFF
--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -174,7 +174,7 @@ public class AdaWebHost: NSObject {
     public func launchModalWebSupport(from viewController: UIViewController) {
         guard let webView = webView else { return }
         webView.translatesAutoresizingMaskIntoConstraints = true
-        let webNavController = AdaWebHostViewController.createNavController(with: webView)
+        let webNavController = AdaWebHostViewController.createNavController(with: webView, adaWebHost: self)
         webNavController.modalPresentationStyle = .overFullScreen
         viewController.present(webNavController, animated: true, completion: nil)
     }
@@ -183,7 +183,7 @@ public class AdaWebHost: NSObject {
     public func launchNavWebSupport(from navController: UINavigationController) {
         guard let webView = webView else { return }
         webView.translatesAutoresizingMaskIntoConstraints = true
-        let webController = AdaWebHostViewController.createWebController(with: webView)
+        let webController = AdaWebHostViewController.createWebController(with: webView, adaWebHost: self)
         navController.pushViewController(webController, animated: true)
     }
     
@@ -231,6 +231,13 @@ extension AdaWebHost {
         }
 
         
+    }
+
+    func teardownWebView() {
+        guard let userContentController = webView?.configuration.userContentController else { return }
+        userContentController.removeScriptMessageHandler(forName: "embedReady")
+        userContentController.removeScriptMessageHandler(forName: "eventCallbackHandler")
+        userContentController.removeScriptMessageHandler(forName: "zdChatterAuthCallbackHandler")
     }
 }
 

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -95,8 +95,8 @@ public class AdaWebHost: NSObject {
         self.reachability = Reachability()!
         super.init()
         
-        reachability.whenReachable = { _ in
-            self.isInOfflineMode = false
+        reachability.whenReachable = { [weak self] _ in
+            self?.isInOfflineMode = false
         }
         
         reachability.whenUnreachable = { [weak self] _ in
@@ -222,7 +222,8 @@ extension AdaWebHost {
         userContentController.add(self, name: "eventCallbackHandler")
         userContentController.add(self, name: "zdChatterAuthCallbackHandler")
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + webViewTimeout) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + webViewTimeout) { [weak self] in
+            guard let self = self else { return }
             if(!self.hasError && webView.isLoading){
                 webView.stopLoading();
                 self.webViewLoadingErrorCallback?(AdaWebHostError.WebViewTimeout)

--- a/EmbedFramework/AdaWebHostViewController.swift
+++ b/EmbedFramework/AdaWebHostViewController.swift
@@ -10,16 +10,18 @@ import UIKit
 import WebKit
 
 class AdaWebHostViewController: UIViewController {
-    static func createWebController(with webView: WKWebView) -> AdaWebHostViewController {
+
+    static func createWebController(with webView: WKWebView, adaWebHost: AdaWebHost) -> AdaWebHostViewController {
         let bundle = Bundle(for: AdaWebHostViewController.self)
         let storyboard = UIStoryboard(name: "AdaWebHostViewController", bundle: bundle)
         guard let viewController = storyboard.instantiateInitialViewController() as? AdaWebHostViewController else { fatalError("This should never, ever happen.") }
         viewController.webView = webView
+        viewController.adaWebHost = adaWebHost
         return viewController
     }
     
-    static func createNavController(with webView: WKWebView) -> UINavigationController {
-        let adaWebHostController = createWebController(with: webView)
+    static func createNavController(with webView: WKWebView, adaWebHost: AdaWebHost) -> UINavigationController {
+        let adaWebHostController = createWebController(with: webView, adaWebHost: adaWebHost)
         let navController = UINavigationController(rootViewController: adaWebHostController)
         
         let doneBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: adaWebHostController, action: #selector(doneButtonTapped(_:)))
@@ -29,6 +31,7 @@ class AdaWebHostViewController: UIViewController {
     }
     
     var webView: WKWebView?
+    weak var adaWebHost: AdaWebHost?
     
     override func loadView() {
         super.loadView()
@@ -36,6 +39,7 @@ class AdaWebHostViewController: UIViewController {
     }
     
     @objc func doneButtonTapped(_ sender: UIBarButtonItem) {
+        adaWebHost?.teardownWebView()
         self.dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
### Description
Fixes the following retain cycles:
-  `reachability.whenReachable` closure
-  `DispatchQueue.main.asyncAfter` closure
- userContentController script message handlers (modal only - still an issue for nav)

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.