### PR TITLE
🦋  Fixed sign-in block and web block functionality

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.3.5"
+  spec.version      = "1.3.6"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"


### PR DESCRIPTION
### Description

When chatters were clicking on webblock or signin block in iOS the interaction was blocked due to window.open javascript event not being allowed.


https://user-images.githubusercontent.com/83093830/120538719-de894600-c3b4-11eb-8e62-3a51acb94700.mov




---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.