### PR TITLE
CHATX-806: Fix for if user manually integrated framework

### DIFF
--- a/EmbedFramework/AdaWebHostViewController.storyboard
+++ b/EmbedFramework/AdaWebHostViewController.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="D6W-gQ-JwA">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="D6W-gQ-JwA">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -55,7 +57,7 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qvu-aw-TnU">
                                                 <rect key="frame" x="0.0" y="157.5" width="280" height="80"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DyO-zH-0Hs">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DyO-zH-0Hs">
                                                         <rect key="frame" x="85" y="10" width="110" height="32"/>
                                                         <color key="backgroundColor" red="0.20256891846656799" green="0.45271092653274536" blue="0.90760737657546997" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                         <constraints>
@@ -91,7 +93,6 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="auu-Pf-WkL"/>
                         <color key="backgroundColor" white="0.0" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="B1c-UZ-eXX" secondAttribute="bottom" id="2fw-wv-cmS"/>
@@ -99,6 +100,7 @@
                             <constraint firstAttribute="trailing" secondItem="B1c-UZ-eXX" secondAttribute="trailing" id="P5o-0D-Uef"/>
                             <constraint firstItem="B1c-UZ-eXX" firstAttribute="top" secondItem="AJC-ml-g1g" secondAttribute="top" id="cDo-Si-Ode"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="auu-Pf-WkL"/>
                     </view>
                     <connections>
                         <outlet property="container" destination="B1c-UZ-eXX" id="t7G-8U-aJH"/>

--- a/EmbedFramework/AdaWebHostViewController.storyboard
+++ b/EmbedFramework/AdaWebHostViewController.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="D6W-gQ-JwA">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="D6W-gQ-JwA">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -57,7 +55,7 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qvu-aw-TnU">
                                                 <rect key="frame" x="0.0" y="157.5" width="280" height="80"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DyO-zH-0Hs">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DyO-zH-0Hs">
                                                         <rect key="frame" x="85" y="10" width="110" height="32"/>
                                                         <color key="backgroundColor" red="0.20256891846656799" green="0.45271092653274536" blue="0.90760737657546997" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                         <constraints>
@@ -93,6 +91,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="auu-Pf-WkL"/>
                         <color key="backgroundColor" white="0.0" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="B1c-UZ-eXX" secondAttribute="bottom" id="2fw-wv-cmS"/>
@@ -100,7 +99,6 @@
                             <constraint firstAttribute="trailing" secondItem="B1c-UZ-eXX" secondAttribute="trailing" id="P5o-0D-Uef"/>
                             <constraint firstItem="B1c-UZ-eXX" firstAttribute="top" secondItem="AJC-ml-g1g" secondAttribute="top" id="cDo-Si-Ode"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="auu-Pf-WkL"/>
                     </view>
                     <connections>
                         <outlet property="container" destination="B1c-UZ-eXX" id="t7G-8U-aJH"/>

--- a/EmbedFramework/AdaWebHostViewController.swift
+++ b/EmbedFramework/AdaWebHostViewController.swift
@@ -12,9 +12,19 @@ import WebKit
 class AdaWebHostViewController: UIViewController {
     static func createWebController(with webView: WKWebView) -> AdaWebHostViewController {
         let bundle = Bundle(for: AdaWebHostViewController.self)
-        let frameworkBundlePath = bundle.path(forResource: "AdaEmbedFramework", ofType: "bundle")!
-        let frameworkBundle = Bundle(path: frameworkBundlePath)
-        let storyboard = UIStoryboard(name: "AdaWebHostViewController", bundle: frameworkBundle)
+        
+        var storyboard:UIStoryboard
+                
+        // Loads the resource_bundle if available (Cocoapod)
+        if (bundle.path(forResource: "AdaEmbedFramework", ofType: "bundle") != nil){
+            let frameworkBundlePath = bundle.path(forResource: "AdaEmbedFramework", ofType: "bundle")!
+            let frameworkBundle = Bundle(path: frameworkBundlePath)
+            storyboard = UIStoryboard(name: "AdaWebHostViewController", bundle: frameworkBundle)
+        } else {
+            // Used for if SDK was manually imported
+            storyboard = UIStoryboard(name: "AdaWebHostViewController", bundle: bundle)
+        }
+        
         guard let viewController = storyboard.instantiateInitialViewController() as? AdaWebHostViewController else { fatalError("This should never, ever happen.") }
         viewController.webView = webView
         return viewController

--- a/EmbedFramework/OfflineViewController.swift
+++ b/EmbedFramework/OfflineViewController.swift
@@ -17,6 +17,9 @@ class OfflineViewController: UIViewController {
     
     static func create() -> OfflineViewController? {
         let bundle = Bundle(for: OfflineViewController.self)
+        
+        var storyboard:UIStoryboard
+        
         // Loads the resource_bundle if available (Cocoapod)
         if (bundle.path(forResource: "AdaEmbedFramework", ofType: "bundle") != nil){
             let frameworkBundlePath = bundle.path(forResource: "AdaEmbedFramework", ofType: "bundle")!

--- a/EmbedFramework/OfflineViewController.swift
+++ b/EmbedFramework/OfflineViewController.swift
@@ -17,9 +17,15 @@ class OfflineViewController: UIViewController {
     
     static func create() -> OfflineViewController? {
         let bundle = Bundle(for: OfflineViewController.self)
-        let frameworkBundlePath = bundle.path(forResource: "AdaEmbedFramework", ofType: "bundle")!
-        let frameworkBundle = Bundle(path: frameworkBundlePath)
-        let storyboard = UIStoryboard(name: "AdaWebHostViewController", bundle: frameworkBundle)
+        // Loads the resource_bundle if available (Cocoapod)
+        if (bundle.path(forResource: "AdaEmbedFramework", ofType: "bundle") != nil){
+            let frameworkBundlePath = bundle.path(forResource: "AdaEmbedFramework", ofType: "bundle")!
+            let frameworkBundle = Bundle(path: frameworkBundlePath)
+            storyboard = UIStoryboard(name: "AdaWebHostViewController", bundle: frameworkBundle)
+        } else {
+            // Used for if SDK was manually imported
+            storyboard = UIStoryboard(name: "AdaWebHostViewController", bundle: bundle)
+        }
         return storyboard.instantiateViewController(withIdentifier: "OfflineViewController") as? OfflineViewController
     }
     


### PR DESCRIPTION
### Description
Latest change to allow for resource bundling with cocoapods broke manual integration. I've added some logic to check if the resource bundle is available (meaning it came though cocoapods) otherwise fallback to using the manual version loading from the root of the project.

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.