### PR TITLE
chatx-963: Add tag for sdktype

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.3.8"
+  spec.version      = "1.3.9"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -86,6 +86,8 @@ public class AdaWebHost: NSObject {
         self.styles = styles
         self.greeting = greeting
         self.metafields = metafields
+//        we always want to append the sdkType
+        self.metafields["sdkType"] = "IOS"
         self.sensitiveMetafields = sensitiveMetafields
         self.openWebLinksInSafari = openWebLinksInSafari
         self.appScheme = appScheme

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import AdaEmbedFramework
 
 class ViewController: UIViewController {
-    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", webViewLoadingErrorCallback: LoadingErrorCallback, webViewTimeout: 30.0)
+    lazy var adaFramework = AdaWebHost(handle: "iambotman", appScheme: "adaexampleapp", webViewLoadingErrorCallback: LoadingErrorCallback, webViewTimeout: 30.0)
     
     @IBOutlet var firstNameField: UITextField!
     @IBOutlet var lastNameField: UITextField!


### PR DESCRIPTION
### Description
Added a default metafield for sdkType to track when bot starts with this SDK

### Why
We want to track how much traffic is coming from each SDK
---
### Checklist

- [x] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.
- [x] PR has been labelled with its [impact level](https://www.notion.so/adasupport/Release-Management-Change-Definitions-c5a239ae075d4cc49bb1066f3e11f39f#b0af5e2c7bc7481a82303fa70b12e4f6)


<img width="576" alt="Screen Shot 2021-11-19 at 2 37 24 PM" src="https://user-images.githubusercontent.com/91202664/142681587-9cd38c4f-a408-4f29-b3cd-c24052c7df9c.png">

