### PR TITLE
Updating ExampleApp to include `data` URL scheme for transcript downloads to work in Example App

### DIFF
--- a/ExampleApp/Info.plist
+++ b/ExampleApp/Info.plist
@@ -26,6 +26,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>adaexampleapp</string>
+				<string>data</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
Updating ExampleApp's Info.plist to include `data` URL scheme so that transcript download feature can be tested in the ExampleApp