### PR TITLE
CHATX-1247: Refactor Download Transcript

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.4.0"
+  spec.version      = "1.4.1"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -496,8 +496,7 @@ extension AdaWebHost {
             evalJS("""
                 (function() {
                     window.adaEmbed.start({
-                        handle: "josephstagingbranch",
-                        domain: "ada-dev2",
+                        handle: "\(self.handle)",
                         cluster: "\(self.cluster)",
                         language: "\(self.language)",
                         styles: "\(self.styles)",


### PR DESCRIPTION
## Description
### iOS 14.5 and Greater
- Using `WKDownloadDelegate` to capture download and begin standard download in iOS

### iOS 14.4 and Older 
- Using regular navigation method to capture navigation to transcript file and pass to `downloadUrl()` function built for original download transcript solution

---
### Checklist

- [x] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [x] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.
- [x] PR has been labelled with its [impact level](https://www.notion.so/adasupport/Release-Management-Change-Definitions-c5a239ae075d4cc49bb1066f3e11f39f#b0af5e2c7bc7481a82303fa70b12e4f6)