### PR TITLE
Added options to setup domain targetting

### DIFF
--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -19,6 +19,7 @@ public class AdaWebHost: NSObject {
     
     private var hasError = false
     public var handle = ""
+    public var domain = ""
     public var cluster = ""
     public var language = ""
     public var styles = ""
@@ -70,6 +71,7 @@ public class AdaWebHost: NSObject {
         handle: String,
         cluster: String = "",
         language: String = "",
+        domain: String = "",
         styles: String = "",
         greeting: String = "",
         metafields: [String: Any] = [:],
@@ -85,6 +87,7 @@ public class AdaWebHost: NSObject {
         self.cluster = cluster
         self.language = language
         self.styles = styles
+        self.domain = domain
         self.greeting = greeting
         self.metafields = metafields
 //        we always want to append the sdkType
@@ -314,6 +317,7 @@ extension AdaWebHost {
         let configuration = WKWebViewConfiguration()
         let userContentController = WKUserContentController()
         let clusterString = cluster.isEmpty ? "" : "\(cluster)."
+        let domainString = domain.isEmpty ? "ada" : "\(domain)"
         configuration.userContentController = userContentController
         configuration.mediaTypesRequiringUserActionForPlayback = []
         configuration.preferences = wkPreferences
@@ -323,7 +327,7 @@ extension AdaWebHost {
         webView.navigationDelegate = self
         webView.uiDelegate = self
         
-        guard let remoteURL = URL(string: "https://\(handle).\(clusterString)ada.support/mobile-sdk-webview/") else { return }
+        guard let remoteURL = URL(string: "https://\(handle).\(clusterString)\(domainString).support/mobile-sdk-webview/") else { return }
         let webRequest = URLRequest(url: remoteURL, cachePolicy: .useProtocolCachePolicy, timeoutInterval: webViewTimeout)
         webView.load(webRequest)
 
@@ -498,6 +502,7 @@ extension AdaWebHost {
                     window.adaEmbed.start({
                         handle: "\(self.handle)",
                         cluster: "\(self.cluster)",
+                        domain: "\(self.domain)",
                         language: "\(self.language)",
                         styles: "\(self.styles)",
                         greeting: "\(self.greeting)",


### PR DESCRIPTION
### Description
Allows for setting different domain when setting up bot. 
This is useful for using bots on different domain such as 'dev' or 'dev2' cluster.

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.
- [x] PR has been labelled with its [impact level](https://www.notion.so/adasupport/Release-Management-Change-Definitions-c5a239ae075d4cc49bb1066f3e11f39f#b0af5e2c7bc7481a82303fa70b12e4f6)