### PR TITLE
SUP-1141: Error callback for IOS when webview takes too long to load

### DIFF
--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -499,8 +499,7 @@ extension AdaWebHost {
             evalJS("""
                 (function() {
                     window.adaEmbed.start({
-                        handle: "michaell",
-                        domain: "ada-dev2",
+                        handle: "\(self.handle)",
                         cluster: "\(self.cluster)",
                         language: "\(self.language)",
                         styles: "\(self.styles)",


### PR DESCRIPTION
### Description
Adding the same error callback implemented for https://github.com/AdaSupport/AndroidSDK/pull/40 to allow app developers to know the webview failed to load (so they can act on it)

---
### Checklist

- [x] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [x] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.
- [x] PR has been labelled with its [impact level](https://www.notion.so/adasupport/Release-Management-Change-Definitions-c5a239ae075d4cc49bb1066f3e11f39f#b0af5e2c7bc7481a82303fa70b12e4f6)