### PR TITLE
chatx-1326: adding set device token

### DIFF
--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -81,7 +81,8 @@ public class AdaWebHost: NSObject {
         zdChatterAuthCallback: (((@escaping (_ token: String) -> Void)) -> Void)? = nil,
         webViewLoadingErrorCallback: ((Error) -> Void)? = nil,
         eventCallbacks: [String: (_ event: [String: Any]) -> Void]? = nil,
-        webViewTimeout: Double = 30.0
+        webViewTimeout: Double = 30.0,
+        deviceToken: String = ""
     ) {
         self.handle = handle
         self.cluster = cluster
@@ -141,10 +142,17 @@ public class AdaWebHost: NSObject {
             print("Unable to start reachability notifier.")
         }
         
+        setDeviceToken(deviceToken: deviceToken)
         setupWebView()
     }
     
     // MARK: - Public Methods
+    
+    public func setDeviceToken(deviceToken : String) {
+        let toRun = "adaEmbed.setDeviceToken(\(deviceToken));"
+        
+        self.evalJS(toRun)
+    }
     
     /// Push a dictionary of fields to the server
     @available(*, deprecated, message: "This method will be deprecated in the future, please upgrade to MetaFields.Builder.", renamed: "setMetaFields(builder:)")


### PR DESCRIPTION
### Description
Adding new public function to allow clients to set device token necessary for push notifications

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.
- [ ] PR has been labelled with its [impact level](https://www.notion.so/adasupport/Release-Management-Change-Definitions-c5a239ae075d4cc49bb1066f3e11f39f#b0af5e2c7bc7481a82303fa70b12e4f6)