### PR TITLE
SUP-1101: Add header background for modal view

### DIFF
--- a/AdaEmbedFramework.podspec
+++ b/AdaEmbedFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "AdaEmbedFramework"
-  spec.version      = "1.5.2"
+  spec.version      = "1.6.0"
   spec.summary      = "Embed the Ada Support SDK in your app."
   spec.description  = "Use the Ada Support SDK to inject the Ada support experience into your app. Visit https://ada.support to learn more."
   spec.homepage     = "https://github.com/AdaSupport/ios-sdk"

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -322,8 +322,6 @@ public class AdaWebHost: NSObject {
             if #available(iOS 13.0, *) {
                 let navBarAppearance = UINavigationBarAppearance()
                 navBarAppearance.configureWithOpaqueBackground()
-                navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
-                navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
                 navBarAppearance.backgroundColor = UIColor(rgb: 0xF3F3F3)
                 webNavController.navigationBar.standardAppearance = navBarAppearance
                 webNavController.navigationBar.scrollEdgeAppearance = navBarAppearance

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -319,7 +319,6 @@ public class AdaWebHost: NSObject {
         if self.navigationBarOpaqueBackground {
             
             webNavController.modalPresentationStyle = .fullScreen
-            webNavController.navigationBar.backgroundColor = UIColor(rgb: 0xF3F3F3)
             if #available(iOS 13.0, *) {
                 let navBarAppearance = UINavigationBarAppearance()
                 navBarAppearance.configureWithOpaqueBackground()

--- a/ExampleApp/ViewController.swift
+++ b/ExampleApp/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import AdaEmbedFramework
 
 class ViewController: UIViewController {
-    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", webViewLoadingErrorCallback: LoadingErrorCallback, webViewTimeout: 30.0)
+    lazy var adaFramework = AdaWebHost(handle: "nic", appScheme: "adaexampleapp", webViewLoadingErrorCallback: LoadingErrorCallback, webViewTimeout: 30.0, navigationBarOpaqueBackground: true)
     
     @IBOutlet var firstNameField: UITextField!
     @IBOutlet var lastNameField: UITextField!


### PR DESCRIPTION
### Description
Client Fetch reported an issue of overlapping content in modal view. This was due to the transparent header.

### Changes
Added neutral grey background to navigation bar and status bar when Embed framework is initialized with `{ navigationBarOpaqueBackground: true }`

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.
- [x] PR has been labelled with its [impact level](https://www.notion.so/adasupport/Release-Management-Change-Definitions-c5a239ae075d4cc49bb1066f3e11f39f#b0af5e2c7bc7481a82303fa70b12e4f6)