### PR TITLE
Added a delegate to AdaWebHost to let apps have control over handling their Universal Link URLs

### DIFF
--- a/AdaEmbedFramework.xcodeproj/project.pbxproj
+++ b/AdaEmbedFramework.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		49C73568226F99FE00D22E4B /* EmbedFrameworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C73567226F99FE00D22E4B /* EmbedFrameworkTests.swift */; };
 		49C7356A226F99FE00D22E4B /* EmbedFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 49C7355C226F99FE00D22E4B /* EmbedFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D62BE845FB815D5E41D3EFA /* Pods_AdaEmbedFramework_AdaEmbedFrameworkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDF945E44BBD03973DD86FC /* Pods_AdaEmbedFramework_AdaEmbedFrameworkTests.framework */; };
+		59B38CC1298DBD380086A2B4 /* AdaWebHost+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B38CC0298DBD380086A2B4 /* AdaWebHost+Delegate.swift */; };
 		936ED6B7228F438800796860 /* AdaWebHostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936ED6B6228F438800796860 /* AdaWebHostViewController.swift */; };
 		936ED6B9228F471800796860 /* AdaWebHostViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 936ED6B8228F471800796860 /* AdaWebHostViewController.storyboard */; };
 		938BBFD122A93F1B000012A9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 938BBFD022A93F1B000012A9 /* Assets.xcassets */; };
@@ -139,6 +140,7 @@
 		49C73562226F99FE00D22E4B /* AdaEmbedFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AdaEmbedFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		49C73567226F99FE00D22E4B /* EmbedFrameworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedFrameworkTests.swift; sourceTree = "<group>"; };
 		49C73569226F99FE00D22E4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		59B38CC0298DBD380086A2B4 /* AdaWebHost+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdaWebHost+Delegate.swift"; sourceTree = "<group>"; };
 		88E7E55B2981D30700F08C85 /* ExampleAppCarthage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ExampleAppCarthage.xcodeproj; path = ExampleAppCarthage/ExampleAppCarthage.xcodeproj; sourceTree = "<group>"; };
 		8D84564760E66C5DB8D387D2 /* Pods-ExampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleApp.release.xcconfig"; path = "Target Support Files/Pods-ExampleApp/Pods-ExampleApp.release.xcconfig"; sourceTree = "<group>"; };
 		8EDF945E44BBD03973DD86FC /* Pods_AdaEmbedFramework_AdaEmbedFrameworkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdaEmbedFramework_AdaEmbedFrameworkTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -349,6 +351,7 @@
 				938BBFD222A94100000012A9 /* OfflineViewController.swift */,
 				938BBFD022A93F1B000012A9 /* Assets.xcassets */,
 				938BBFD422A94304000012A9 /* Reachability.swift */,
+				59B38CC0298DBD380086A2B4 /* AdaWebHost+Delegate.swift */,
 			);
 			path = EmbedFramework;
 			sourceTree = "<group>";
@@ -597,6 +600,7 @@
 			files = (
 				938BBFD322A94100000012A9 /* OfflineViewController.swift in Sources */,
 				936ED6B7228F438800796860 /* AdaWebHostViewController.swift in Sources */,
+				59B38CC1298DBD380086A2B4 /* AdaWebHost+Delegate.swift in Sources */,
 				938BBFD522A94304000012A9 /* Reachability.swift in Sources */,
 				93A79798228C871200499BF9 /* AdaWebHost.swift in Sources */,
 			);

--- a/EmbedFramework/AdaWebHost+Delegate.swift
+++ b/EmbedFramework/AdaWebHost+Delegate.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public protocol AdaWebHostDelegate: AnyObject {
+    /// Use this function to handle urls inside the app.
+    /// Should return false if app will handle the url.
+    func adaWebHost(_ host: AdaWebHost, shouldOpenUrl url: URL) -> Bool
+}
+
+public extension AdaWebHostDelegate {
+    func adaWebHost(_ host: AdaWebHost, shouldOpenUrl url: URL) -> Bool {
+        true
+    }
+}

--- a/EmbedFramework/AdaWebHost.swift
+++ b/EmbedFramework/AdaWebHost.swift
@@ -44,7 +44,7 @@ public class AdaWebHost: NSObject {
     public var greeting = ""
     public var deviceToken = ""
     public var webViewTimeout = 30.0
-    
+    public weak var delegate: AdaWebHostDelegate?
     
     /// Metafields can be passed in during init; use `setMetaFields()` and `setSensitiveMetafields()`
     /// to send values in at runtime
@@ -434,6 +434,10 @@ extension AdaWebHost: WKNavigationDelegate, WKUIDelegate, WKDownloadDelegate {
     
     // Shared function to handle opening of urls
     public func openUrl(webView: WKWebView, url: URL) -> Swift.Void {
+        guard let delegate,
+              delegate.adaWebHost(self, shouldOpenUrl: url)
+        else { return }
+        
         let httpSchemes = ["http", "https"]
         let urlScheme = url.scheme
         // Handle opening universal links within the host App


### PR DESCRIPTION
### Description
* Added a new file for AdaWebHost delegate: `AdaWebHost+Delegate.swift`
* Added a new Protocol: `AdaWebHostDelegatel`
* Added a default implementation for `func adaWebHost(_ host: AdaWebHost, shouldOpenUrl url: URL) -> Bool` to have an all-pass implementation.
* Added a weak reference to an instance of `AdaWebHostDelegate` to `AdaWebHost`
* Updated `func openUrl(webView: url:) -> Swift.Void` to check if a delegate exists and if the delegate can/will handle the provided URL. If the delegate should handle the URL, it should also return `false` in response and this function will be bypassed.

This will be an opt-in solution for any framework user to adopt and doesn't have any breaking syntax or functionality changes.
---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.
- [ ] PR has been labelled with its [impact level](https://www.notion.so/adasupport/Release-Management-Change-Definitions-c5a239ae075d4cc49bb1066f3e11f39f#b0af5e2c7bc7481a82303fa70b12e4f6)