### PR TITLE
Add link to embed architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Ada iOS SDK
 
 Docs for the iOS SDK can be found [here](https://developers.ada.cx/reference/ios-sdk-quick-start).
+
+## Architecture
+See the [Embed README](https://github.com/AdaSupport/embed-2?tab=readme-ov-file#architecture) for information about architecture.


### PR DESCRIPTION
### Description
Provide a link to Embed's architecture section. This is part of the work to add better documentation for which services are associated with Embed

---
### Checklist

- [ ] The steps for distribution have been follow [here](https://www.notion.so/adasupport/Distribution-3a9dfc90c9b3449781b6f9c825f1dee8).
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master.
- [ ] PR has been labelled with its [impact level](https://www.notion.so/adasupport/Release-Management-Change-Definitions-c5a239ae075d4cc49bb1066f3e11f39f#b0af5e2c7bc7481a82303fa70b12e4f6)